### PR TITLE
Add Design-to-Deploy board sentence to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # alice-fst-20260312000133
 Ephemeral full system test repo - 2026-03-12T00:01:33.1115958Z
+
+This project supports the Design-to-Deploy board.


### PR DESCRIPTION
Adds the sentence 'This project supports the Design-to-Deploy board.' to README.md as specified in issue #1.

Fixes #1